### PR TITLE
Fix README headings grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # CRUD Users
 Simple application that store data about users in a database.
 
-## How build this application ##
+## How to build this application ##
 Run the following command from root of repository:
 ```bash
 mvn clean package
 ```
 
-## How create a new image ##
+## How to create a new image ##
 Run the following command from root of repository:
 ```bash
 docker build -t ivancl4udio/crud-users:1.0.0 .
 ```
 
-## How run this application with h2 database ##
+## How to run this application with h2 database ##
 Run the following command from root of repository:
 ```bash
 mvn spring-boot:run
 ```
 
-## How run this application with a Postgresql database ##
+## How to run this application with a PostgreSQL database ##
 Run the following command from root of repository:
 ```bash
 export SPRING_DATASOURCE_URL=jdbc:postgresql://database-name:5432/postgres
@@ -29,7 +29,7 @@ export SPRING_JPA_HIBERNATE_DDL_AUTO=update
 mvn spring-boot:run
 ```
 
-## How run this application with a postgresql database and docker-compose ##
+## How to run this application with a PostgreSQL database and docker-compose ##
 Run the following command from root of repository:
 ```bash
 docker-compose up


### PR DESCRIPTION
## Summary
- correct README heading grammar

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e69334bc832da6ed354eadfe842c