### PR TITLE
Fix repository test expecting wrong id

### DIFF
--- a/src/test/java/com/ivancl4udio/cruduser/UserRepositoryUnitTests.java
+++ b/src/test/java/com/ivancl4udio/cruduser/UserRepositoryUnitTests.java
@@ -59,7 +59,7 @@ class UserRepositoryUnitTests {
 
         //Then
         assertNotNull(userSaved);
-        assertEquals(3, userSaved.getId().longValue());
+        assertEquals(2, userSaved.getId().longValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- correct expected id in `save_should_insert_new_user` test

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849e83399f8832dbf4c80e42eac39a2